### PR TITLE
docs: add bilingual project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cVAE API
 
 ## Overview
-The cVAE API is a Flask-based service that exposes a conditional variational autoencoder (cVAE) trained to predict planetary interior distributions. The application loads a pretrained PyTorch model together with feature scalers and offers JSON as well as file-based inference endpoints so you can request probabilistic distributions for interior structure parameters from bulk planetary measurements.
+The cVAE API is a Flask-based service that exposes a conditional variational autoencoder (cVAE) trained to predict the interior structure of rocky exoplanets. The application loads a pretrained PyTorch model together with feature scalers and offers JSON as well as file-based inference endpoints so you can request probabilistic distributions for interior structure parameters from bulk planetary measurements.
 
 ## Features
 - Loads a pretrained cVAE model and the associated feature scalers at startup for deterministic inference results.
@@ -26,6 +26,7 @@ The cVAE API is a Flask-based service that exposes a conditional variational aut
 - Python 3.10+
 - Dependencies listed in `requirements.txt` (Flask, PyTorch, pandas, etc.).
 - Pretrained assets placed in `static/best_model.pth`, `static/Xscaler.save`, and `static/yscaler.save`.
+- At least 1 GB of available memory to load the pretrained model and scalers.
 
 ## Local development
 1. Create and activate a virtual environment.
@@ -33,12 +34,12 @@ The cVAE API is a Flask-based service that exposes a conditional variational aut
    ```bash
    pip install -r requirements.txt
    ```
-3. Export the Flask application entry point and start the development server:
+3. Export the Flask application entry point and start the development server (binding to port `8000`):
    ```bash
    export FLASK_APP=app:create_app
-   flask run --debug
+   flask run --debug --port 8000
    ```
-   The API will be available at `http://127.0.0.1:5000/api/`.
+   The API will be available at `http://127.0.0.1:8000/api/`.
 
 To run the service with Gunicorn (recommended for production):
 ```bash
@@ -50,6 +51,10 @@ All endpoints are namespaced under `/api`.
 
 ### `GET /api/hello`
 Health-check endpoint that returns a plain text greeting.
+
+```bash
+curl http://127.0.0.1:8000/api/hello
+```
 
 ### `POST /api/single_prediction`
 Accepts JSON containing scalar or vector inputs for the four required features. Each feature should be provided as a list to allow batch predictions. Optional `Times` controls the number of samples drawn for each input (default 10). Example:
@@ -64,6 +69,18 @@ Accepts JSON containing scalar or vector inputs for the four required features. 
 ```
 The response contains the received payload and a `Prediction_distribution` map keyed by the batch index.
 
+```bash
+curl -X POST http://127.0.0.1:8000/api/single_prediction \
+  -H "Content-Type: application/json" \
+  -d '{
+        "Mass": [1.0],
+        "Radius": [1.0],
+        "Fe/Mg": [0.5],
+        "Si/Mg": [1.0],
+        "Times": 25
+      }'
+```
+
 ### `POST /api/multi_prediction`
 Identical payload contract as `single_prediction`. This endpoint is intended for submitting multiple planetary cases at once.
 
@@ -76,11 +93,11 @@ Returns a JSON object that contains the predicted distributions for each input r
 
 ## Model outputs
 Predictions include distributions for the following parameters:
-- `WRF`
-- `MRF`
-- `CRF`
-- `WMF`
-- `CMF`
+- `WRF` – water radial fraction
+- `MRF` – mantle radial fraction
+- `CRF` – core radial fraction
+- `WMF` – water mass fraction
+- `CMF` – core mass fraction
 - `P_CMB (TPa)` – core-mantle boundary pressure (terapascal)
 - `T_CMB (10^3K)` – core-mantle boundary temperature (thousands of Kelvin)
 - `K2` – tidal Love number

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# cVAE API
+
+## Overview
+The cVAE API is a Flask-based service that exposes a conditional variational autoencoder (cVAE) trained to predict planetary interior distributions. The application loads a pretrained PyTorch model together with feature scalers and offers JSON as well as file-based inference endpoints so you can request probabilistic distributions for interior structure parameters from bulk planetary measurements.
+
+## Features
+- Loads a pretrained cVAE model and the associated feature scalers at startup for deterministic inference results.
+- Supports scalar JSON inputs, batched JSON inputs, and file uploads (NumPy, CSV, Excel, and Parquet) for prediction requests.
+- Automatically handles missing `Times` values by falling back to a default of 10 predictive samples per input row.
+- Returns distributions for eight interior structure parameters, including weight and composition-related factors, in SI-friendly units.
+
+## Project structure
+```
+.
+├── app/
+│   ├── __init__.py        # Flask application factory and model initialisation
+│   ├── routes.py          # REST API endpoints and inference helpers
+│   ├── config.py          # Shared configuration constants
+│   └── cvae.py            # Model architecture definitions
+├── static/                # Pretrained weights and scaler artefacts
+├── requirements.txt       # Python runtime dependencies
+└── gunicorn_conf.py       # Production Gunicorn configuration
+```
+
+## Requirements
+- Python 3.10+
+- Dependencies listed in `requirements.txt` (Flask, PyTorch, pandas, etc.).
+- Pretrained assets placed in `static/best_model.pth`, `static/Xscaler.save`, and `static/yscaler.save`.
+
+## Local development
+1. Create and activate a virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Export the Flask application entry point and start the development server:
+   ```bash
+   export FLASK_APP=app:create_app
+   flask run --debug
+   ```
+   The API will be available at `http://127.0.0.1:5000/api/`.
+
+To run the service with Gunicorn (recommended for production):
+```bash
+gunicorn --config gunicorn_conf.py 'app:create_app()'
+```
+
+## API reference
+All endpoints are namespaced under `/api`.
+
+### `GET /api/hello`
+Health-check endpoint that returns a plain text greeting.
+
+### `POST /api/single_prediction`
+Accepts JSON containing scalar or vector inputs for the four required features. Each feature should be provided as a list to allow batch predictions. Optional `Times` controls the number of samples drawn for each input (default 10). Example:
+```json
+{
+  "Mass": [1.0],
+  "Radius": [1.0],
+  "Fe/Mg": [0.5],
+  "Si/Mg": [1.0],
+  "Times": 25
+}
+```
+The response contains the received payload and a `Prediction_distribution` map keyed by the batch index.
+
+### `POST /api/multi_prediction`
+Identical payload contract as `single_prediction`. This endpoint is intended for submitting multiple planetary cases at once.
+
+### `POST /api/file_prediction`
+Accepts multipart form-data with:
+- `file`: uploaded `.npy`, `.csv`, `.xlsx`, or `.parquet` file containing the four feature columns in the order `[Mass, Radius, Fe/Mg, Si/Mg]`.
+- Optional `Times` form field (defaults to 10).
+
+Returns a JSON object that contains the predicted distributions for each input row. Mass and radius derived quantities in the output are rescaled to original units before being returned.
+
+## Model outputs
+Predictions include distributions for the following parameters:
+- `WRF`
+- `MRF`
+- `CRF`
+- `WMF`
+- `CMF`
+- `P_CMB (TPa)` – core-mantle boundary pressure (terapascal)
+- `T_CMB (10^3K)` – core-mantle boundary temperature (thousands of Kelvin)
+- `K2` – tidal Love number
+
+## Contributing
+Pull requests are welcome. Please ensure code is formatted and that new features include suitable documentation updates.
+
+## License
+Specify the project license here if available.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,91 @@
+# cVAE API
+
+## 项目概述
+cVAE API 是一个基于 Flask 的服务，用于暴露已训练好的条件变分自编码器（conditional Variational Autoencoder，cVAE），通过行星的整体观测量来推断其内部结构的概率分布。应用在启动时会加载预训练的 PyTorch 模型和特征缩放器，支持以 JSON 或文件上传的方式进行推理。
+
+## 主要特性
+- 在应用启动时加载预训练的 cVAE 模型与缩放器，确保推理结果可复现。
+- 支持标量 JSON 输入、批量 JSON 输入以及 `.npy`、`.csv`、`.xlsx`、`.parquet` 等文件格式的预测请求。
+- 当未提供 `Times` 参数时会自动使用默认值 10，表示为每条输入生成 10 组样本。
+- 输出包含八个行星内部结构相关参数，并对压力和温度等量纲进行了单位还原。
+
+## 目录结构
+```
+.
+├── app/
+│   ├── __init__.py        # Flask 应用工厂及模型加载
+│   ├── routes.py          # REST API 路由与推理逻辑
+│   ├── config.py          # 配置常量
+│   └── cvae.py            # cVAE 模型结构定义
+├── static/                # 预训练权重与缩放器
+├── requirements.txt       # 运行依赖
+└── gunicorn_conf.py       # Gunicorn 配置
+```
+
+## 环境要求
+- Python 3.10 及以上
+- `requirements.txt` 中列出的依赖（Flask、PyTorch、pandas 等）。
+- 将预训练资源放置于 `static/best_model.pth`、`static/Xscaler.save`、`static/yscaler.save`。
+
+## 本地运行
+1. 创建并激活虚拟环境。
+2. 安装依赖：
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. 设置 Flask 入口并启动开发服务器：
+   ```bash
+   export FLASK_APP=app:create_app
+   flask run --debug
+   ```
+   默认监听 `http://127.0.0.1:5000/api/`。
+
+若需使用 Gunicorn（生产环境推荐）：
+```bash
+gunicorn --config gunicorn_conf.py 'app:create_app()'
+```
+
+## 接口说明
+所有接口均以 `/api` 为前缀。
+
+### `GET /api/hello`
+健康检查接口，返回简单的问候字符串。
+
+### `POST /api/single_prediction`
+请求体为 JSON，需提供四个必需特征（`Mass`、`Radius`、`Fe/Mg`、`Si/Mg`），每个字段建议使用列表形式以支持批量推理，可选字段 `Times` 控制每条输入生成的样本数量（默认 10）。示例：
+```json
+{
+  "Mass": [1.0],
+  "Radius": [1.0],
+  "Fe/Mg": [0.5],
+  "Si/Mg": [1.0],
+  "Times": 25
+}
+```
+响应会包含原始请求和按批次索引划分的 `Prediction_distribution` 结果。
+
+### `POST /api/multi_prediction`
+与 `single_prediction` 接口的请求格式相同，主要用于同时提交多组行星数据。
+
+### `POST /api/file_prediction`
+接收 multipart form-data：
+- `file`：上传包含四个特征列（顺序为 `[Mass, Radius, Fe/Mg, Si/Mg]`）的 `.npy`、`.csv`、`.xlsx` 或 `.parquet` 文件。
+- 可选 `Times` 表单字段（默认 10）。
+
+接口会返回每行输入对应的预测分布，质量和半径相关的输出会在返回前转换回原始单位。
+
+## 模型输出参数
+- `WRF`
+- `MRF`
+- `CRF`
+- `WMF`
+- `CMF`
+- `P_CMB (TPa)` —— 核幔边界压力（TeraPascal）
+- `T_CMB (10^3K)` —— 核幔边界温度（以千开尔文为单位）
+- `K2` —— 潮汐 Love 数
+
+## 贡献指南
+欢迎提交 Pull Request。请确保代码格式规范，并为新功能补充相应的文档说明。
+
+## 许可协议
+如有许可证，请在此处说明。

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  cvae-api:
+    image: xavierxx/cvae-api:master
+    container_name: cvae-api
+    ports:
+      - "8000:8000"   # 左边是宿主机端口，可改；右边是容器暴露端口
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add an English README that documents the API capabilities, setup steps, and endpoints
- provide a Chinese README counterpart with equivalent instructions for local usage and API reference

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cba60a4dbc8322a5b52ea9ec90bfed